### PR TITLE
Log the execSync result for debugging

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -60,11 +60,11 @@ function run() {
 
   try {
     if (setupCommand) {
-      execSync(setupCommand, {timeout})
+      execSync(setupCommand, {timeout, env, stdio: 'inherit'})
     }
 
     startTime = new Date()
-    output = execSync(command, {timeout, env}).toString()
+    output = execSync(command, {timeout, env, stdio: 'inherit'}).toString()
     endTime = new Date()
 
     result = generateResult('pass', testName, command, output, endTime - startTime, maxScore)


### PR DESCRIPTION
Send the results of the `execSync` calls to the console for easier debugging. This came up due to: https://github.com/orgs/community/discussions/106545#discussioncomment-8893352. It would have been an easy fix for the teacher if we had surfaced that it was failing because `gdown` was not installed. 