### PR TITLE
Working directory and environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,11 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
     - name: Run Autograding Tests
-      uses: education/autograding-command-grader@v1
+      uses: education/autograding-command-grader@v2
+      env: 
+        VARIABLE: value
       with:
+        working-directory: './src'
         test-name: 'Test Name'
         setup-command: 'npm install'
         command: 'npm test'

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,9 @@ inputs:
   setup-command:
     description: "Command to execute prior to the test, typically for environment setup or dependency installation."
     required: false
+  working-directory:
+    description: "Which is the working directory in which you execute tests."
+    required: false
   command:
     description: "Primary command to run for the test. A zero exit code signifies a successful test."
     required: true

--- a/src/main.js
+++ b/src/main.js
@@ -52,6 +52,12 @@ function run() {
   const command = core.getInput('command', {required: true})
   const timeout = parseFloat(core.getInput('timeout') || 10) * 60000 // Convert to minutes
   const maxScore = parseInt(core.getInput('max-score') || 0)
+  const workingDirectory = core.getInput('working-directory')
+
+  const processEnv = {
+    ...process.env,
+    ...env,
+  }
 
   let output = ''
   let startTime
@@ -60,11 +66,11 @@ function run() {
 
   try {
     if (setupCommand) {
-      execSync(setupCommand, {timeout, env, stdio: 'inherit'})
+      execSync(setupCommand, {timeout, cwd: workingDirectory, env: processEnv, stdio: 'inherit'})
     }
 
     startTime = new Date()
-    output = execSync(command, {timeout, env, stdio: 'inherit'})?.toString()
+    output = execSync(command, { cwd: workingDirectory, timeout, env: processEnv, stdio: 'inherit'})?.toString()
     endTime = new Date()
 
     result = generateResult('pass', testName, command, output, endTime - startTime, maxScore)


### PR DESCRIPTION
Adds support to specify working directory where tests are executed. This is helpful when multiple tests are executed in different parts of the projects (e.g. in monorepos)

Also, it solves the problem where environment variables from the action are not included in the command execution and only subset specified in the action was passed.

```
  const processEnv = {
    ...process.env,
    ...env,
  }

  execSync(setupCommand, {timeout, cwd: workingDirectory, env: processEnv, stdio: 'inherit'})
```